### PR TITLE
add tests for search extent

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: arcgisgeocode
 Title: A Robust Interface to ArcGIS Geocode Services
-Version: 0.0.0.9005
+Version: 0.0.0.9006
 Authors@R: 
     person("Josiah", "Parry", , "josiah.parry@gmail.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0001-9910-865X"))

--- a/R/core-batch-geocode.R
+++ b/R/core-batch-geocode.R
@@ -62,7 +62,7 @@ geocode_addresses <- function(
 
 
   check_bool(.progress, allow_na = FALSE, allow_null = FALSE)
-  check_for_storage(for_storage, token, call = rlang::current_env())
+  check_for_storage(for_storage, token)
 
   # type checking for all character types
   # they can be either NULL or not. When not, they cannot have NA values
@@ -100,14 +100,12 @@ geocode_addresses <- function(
   # searchExtent
   check_extent(
     search_extent,
-    arg = rlang::caller_arg(search_extent),
-    call = rlang::current_env()
+    arg = rlang::caller_arg(search_extent)
   )
 
   if (!is.null(search_extent)) {
     extent_crs <- validate_crs(
-      sf::st_crs(search_extent),
-      call = rlang::current_env()
+      sf::st_crs(search_extent)
     )[[1]]
 
     extent_json_raw <- c(
@@ -271,8 +269,7 @@ geocode_addresses <- function(
     string <- httr2::resp_body_string(.resp)
     parse_locations_res(
       string,
-      use_custom_json_processing,
-      call = rlang::current_env()
+      use_custom_json_processing
     )
   })
 

--- a/R/core-find-candidates.R
+++ b/R/core-find-candidates.R
@@ -101,7 +101,7 @@ find_address_candidates <- function(
   }
 
   # this also checks the token
-  check_for_storage(for_storage, token, call = rlang::current_env())
+  check_for_storage(for_storage, token, call = rlang::caller_env())
 
   check_bool(.progress, allow_na = FALSE, allow_null = FALSE)
 
@@ -138,7 +138,7 @@ find_address_candidates <- function(
     min = 1,
     max = 50,
     allow_null = TRUE,
-    call = rlang::current_env()
+    call = rlang::caller_env()
   )
 
   # check that either single_line or address are not-null
@@ -159,7 +159,7 @@ find_address_candidates <- function(
   null_args <- vapply(all_args, is.null, logical(1))
 
   # these arguments are scalars and shold not be handled in a vectorized manner
-  to_exclude <- c("crs", ".progress", "token", "geocoder", "for_storage")
+  to_exclude <- c("crs", ".progress", "token", "geocoder", "for_storage", "search_extent")
   to_include <- !names(all_args) %in% to_exclude
 
   # fetches all non-null arguments. These will be turned into a dataframe
@@ -211,7 +211,10 @@ find_address_candidates <- function(
 
   # handle extent
   # only 1 extent per function call, this will not be vectorized
-  check_extent(search_extent, arg = rlang::caller_arg(search_extent), call = call)
+  check_extent(
+    search_extent,
+    arg = rlang::caller_arg(search_extent)
+  )
 
   if (!is.null(search_extent)) {
     extent_crs <- validate_crs(

--- a/R/core-suggest.R
+++ b/R/core-suggest.R
@@ -72,8 +72,7 @@ suggest_places <- function(
   # searchExtent
   check_extent(
     search_extent,
-    arg = rlang::caller_arg(search_extent),
-    call = rlang::current_env()
+    arg = rlang::caller_arg(search_extent)
   )
 
 
@@ -94,8 +93,7 @@ suggest_places <- function(
     max_suggestions,
     min = 1,
     max = 15,
-    allow_null = TRUE,
-    call = rlang::current_env()
+    allow_null = TRUE
   )
 
   check_iso_3166(country_code, scalar = TRUE)

--- a/R/utils-checks.R
+++ b/R/utils-checks.R
@@ -83,7 +83,7 @@ check_extent <- function(
     extent,
     allow_null = TRUE,
     arg = rlang::caller_arg(extent),
-    call = rlang::caller_env()) {
+    call = rlang::caller_call()) {
   if (is.null(extent)) {
     return(invisible(NULL))
   }
@@ -115,7 +115,7 @@ obj_as_points <- function(
     x,
     allow_null = TRUE,
     arg = rlang::caller_arg(x),
-    call = rlang::current_env()) {
+    call = rlang::caller_env()) {
   if (is.null(x) && allow_null) {
     return(NULL)
   } else if (rlang::inherits_any(x, "POINT")) {

--- a/R/utils-geocoder-obj.R
+++ b/R/utils-geocoder-obj.R
@@ -47,7 +47,7 @@ print.GeocodeServer <- function(x, ...) {
 }
 
 # handy check function to see if the type is a GeocodeServer
-check_geocoder <- function(x, arg = rlang::caller_arg(x), call = rlang::current_env()) {
+check_geocoder <- function(x, arg = rlang::caller_arg(x), call = rlang::caller_env()) {
   if (!rlang::inherits_any(x, "GeocodeServer")) {
     cli::cli_abort("Expected {.cls GeocodeServer}, {.arg {arg}} is {obj_type_friendly(x)}")
   }

--- a/tests/testthat/test-search-extent.R
+++ b/tests/testthat/test-search-extent.R
@@ -1,0 +1,71 @@
+bbox <- sf::st_point(c(-122.307, 47.654)) |>
+  sf::st_sfc(crs = 4326) |>
+  sf::st_transform(3857) |>
+  sf::st_buffer(5000) |>
+  sf::st_transform(4326) |>
+  sf::st_bbox()
+
+test_that("find_address_candidate(): search_extent is respected", {
+  expect_no_error(
+    find_address_candidates(
+      "4130 Roosevelt Way NE",
+      search_extent = bbox
+    )
+  )
+})
+
+test_that("find_address_candidate(): search_extent must be a bbox", {
+  expect_error(
+    find_address_candidates(
+      "4130 Roosevelt Way NE",
+      search_extent = list(bbox)
+    )
+  )
+})
+
+
+test_that("geocode_addresses(): search_extent is respected", {
+  skip_on_ci()
+  skip_if(!interactive(), "Must be done manually")
+
+  set_arc_token(auth_user())
+  expect_no_error(
+    geocode_addresses(
+      "4130 Roosevelt Way NE",
+      search_extent = bbox
+    )
+  )
+})
+
+test_that("geocode_addresses(): search_extent must be a bbox", {
+  set_arc_token(auth_user())
+  expect_error(
+    geocode_addresses(
+      "4130 Roosevelt Way NE",
+      search_extent = list(bbox)
+    )
+  )
+})
+
+test_that("suggest_places(): search_extent is respected", {
+  skip_on_ci()
+  skip_if(!interactive(), "Must be done manually")
+
+  set_arc_token(auth_user())
+  expect_no_error(
+    suggest_places(
+      "espresso",
+      search_extent = bbox
+    )
+  )
+})
+
+test_that("suggest_places(): search_extent must be a bbox", {
+  set_arc_token(auth_user())
+  expect_error(
+    suggest_places(
+      "4130 Roosevelt Way NE",
+      search_extent = list(bbox)
+    )
+  )
+})


### PR DESCRIPTION
This PR fixes a bug that counted the length of a bbox and compared it to the inputs when it should've been ignored. 