### PR TITLE
Fix custom locator json parsing

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: arcgisgeocode
 Title: A Robust Interface to ArcGIS 'Geocoding Services'
-Version: 0.1.0
+Version: 0.1.1
 Authors@R: 
     person("Josiah", "Parry", , "josiah.parry@gmail.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0001-9910-865X"))

--- a/R/core-batch-geocode.R
+++ b/R/core-batch-geocode.R
@@ -290,7 +290,9 @@ geocode_addresses <- function(
     string <- httr2::resp_body_string(.resp)
     parse_locations_res(
       string,
-      use_custom_json_processing
+      use_custom_json_processing,
+      n,
+      geocoder
     )
   })
 
@@ -400,6 +402,11 @@ sort_asap <- function(.df, .col, call = rlang::caller_env()) {
   check_data_frame(.df)
 
   if (nrow(.df) == 0) {
+    return(.df)
+  }
+
+  if (is.null(.df[[.col]])) {
+    cli::cli_warn("Column {.val result_id} is not present. Results may be out of order.")
     return(.df)
   }
 


### PR DESCRIPTION
Closes https://github.com/R-ArcGIS/arcgisgeocode/issues/20

This fixes a (mind-numbingly simple!) bug where the additional arguments needed to parse custom locator responses was not being passed along.

This also illustrated a bug where if using a custom locator the result_id field is not always present. If that is the case, the output will not be sorted. A warning is elicited in that situation. 