### PR TITLE
Fix minor issues #35 and #36

### DIFF
--- a/R/core-batch-geocode.R
+++ b/R/core-batch-geocode.R
@@ -162,7 +162,7 @@ geocode_addresses <- function(
 
   if (!is.null(single_line)) {
     too_long <- nchar(single_line) > 200
-    if (any(too_long)) {
+    if (any(too_long, na.rm = TRUE)) {
       ids <- which(too_long)
       cli::cli_abort(
         c(

--- a/R/doc-data.R
+++ b/R/doc-data.R
@@ -1,4 +1,12 @@
-utils::globalVariables(c("world_geocoder", "esri_wkids"))
+# Make world_geocoder and esri_wkids available on load
+.onLoad <- function(lib, pkg) {
+  utils::data(
+    list = c("world_geocoder", "esri_wkids"),
+    package = pkg,
+    envir = parent.env(environment())
+  )
+}
+
 #' ArcGIS World Geocoder
 #'
 #' The [ArcGIS World Geocoder](https://www.esri.com/en-us/arcgis/products/arcgis-world-geocoder)

--- a/R/doc-data.R
+++ b/R/doc-data.R
@@ -1,12 +1,3 @@
-# Make world_geocoder and esri_wkids available on load
-.onLoad <- function(lib, pkg) {
-  utils::data(
-    list = c("world_geocoder", "esri_wkids"),
-    package = pkg,
-    envir = parent.env(environment())
-  )
-}
-
 #' ArcGIS World Geocoder
 #'
 #' The [ArcGIS World Geocoder](https://www.esri.com/en-us/arcgis/products/arcgis-world-geocoder)

--- a/R/utils-crs.R
+++ b/R/utils-crs.R
@@ -13,7 +13,7 @@
 #' @keywords internal
 #' @noRd
 parse_wkid <- function(wkid) {
-  is_esri_srid <- any(wkid == esri_wkids)
+  is_esri_srid <- any(wkid == arcgisgeocode::esri_wkids)
   if (is_esri_srid) {
     sf::st_crs(paste("ESRI", wkid, sep = ":"))
   } else {

--- a/R/utils-geocoder-obj.R
+++ b/R/utils-geocoder-obj.R
@@ -68,5 +68,12 @@ capabilities <- function(geocoder) {
 #' @keywords internal
 #' @noRd
 has_custom_fields <- function(x) {
-  length(setdiff(x$candidateFields$name, world_geocoder$candidateFields$name)) > 0
+  fields <- length(
+    setdiff(
+      x$candidateFields$name,
+      arcgisgeocode::world_geocoder$candidateFields$name
+    )
+  )
+
+  fields > 0
 }

--- a/R/utils-geocoder-obj.R
+++ b/R/utils-geocoder-obj.R
@@ -68,12 +68,10 @@ capabilities <- function(geocoder) {
 #' @keywords internal
 #' @noRd
 has_custom_fields <- function(x) {
-  fields <- length(
-    setdiff(
-      x$candidateFields$name,
-      arcgisgeocode::world_geocoder$candidateFields$name
-    )
+  custom_fields <- setdiff(
+    x$candidateFields$name,
+    arcgisgeocode::world_geocoder$candidateFields$name
   )
 
-  fields > 0
+  length(custom_fields) > 0
 }


### PR DESCRIPTION
I ran into both issues while trying out the package this afternoon. Here is a reprex using the version from my fork:

``` r
arcgisgeocode::geocode_addresses(
  "10 N Calvert Street",
  geocoder = arcgisgeocode::geocode_server(
    "https://egis.baltimorecity.gov/egis/rest/services/Locator/EGISCompositeLocator/GeocodeServer"
  )
)
#> Simple feature collection with 1 feature and 59 fields
#> Geometry type: POINT
#> Dimension:     XY
#> Bounding box:  xmin: 1421984 ymin: 591503.9 xmax: 1421984 ymax: 591503.9
#> Projected CRS: NAD_1983_StatePlane_Maryland_FIPS_1900_Feet
#>   result_id     loc_name status score                            match_addr
#> 1         1 EGIS_Address      M   100 10 N CALVERT ST, Baltimore, MD, 21202
#>                              long_label     short_label    addr_type type_field
#> 1 10 N CALVERT ST, Baltimore, MD, 21202 10 N CALVERT ST PointAddress       <NA>
#>   place_name                            place_addr phone  url rank add_bldg
#> 1       <NA> 10 N CALVERT ST, Baltimore, MD, 21202  <NA> <NA>   20     <NA>
#>   add_num add_num_from add_num_to add_range side st_pre_dir st_pre_type st_name
#> 1      10         <NA>       <NA>      <NA> <NA>       <NA>           N CALVERT
#>   st_type st_dir bldg_type bldg_name level_type level_name unit_type unit_name
#> 1      ST   <NA>      <NA>      <NA>       <NA>       <NA>      <NA>      <NA>
#>   sub_addr         st_addr block sector nbrhd district      city metro_area
#> 1     <NA> 10 N CALVERT ST  <NA>   <NA>  <NA>     <NA> Baltimore       <NA>
#>        subregion region region_abbr territory zone postal postal_ext country
#> 1 Baltimore City     MD        <NA>      <NA> <NA>  21202       <NA>    <NA>
#>   cntry_name lang_code distance       x        y display_x display_y    xmin
#> 1         US       ENG        0 1421984 591503.9   1421984  591503.9 1421703
#>      xmax     ymin     ymax ex_info                 geometry
#> 1 1422266 591138.5 591869.3    <NA> POINT (1421984 591503.9)

library(arcgisgeocode)

geocode_addresses(
  NA_character_,
  geocoder = geocode_server(
    "https://egis.baltimorecity.gov/egis/rest/services/Locator/EGISCompositeLocator/GeocodeServer"
  )
)
#> Simple feature collection with 1 feature and 59 fields (with 1 geometry empty)
#> Geometry type: POINT
#> Dimension:     XY
#> Bounding box:  xmin: NA ymin: NA xmax: NA ymax: NA
#> Projected CRS: NAD_1983_StatePlane_Maryland_FIPS_1900_Feet
#>   result_id loc_name status score match_addr long_label short_label addr_type
#> 1         1               U     0       <NA>       <NA>        <NA>      <NA>
#>   type_field place_name place_addr phone  url rank add_bldg add_num
#> 1       <NA>       <NA>       <NA>  <NA> <NA>    0     <NA>    <NA>
#>   add_num_from add_num_to add_range side st_pre_dir st_pre_type st_name st_type
#> 1         <NA>       <NA>      <NA> <NA>       <NA>        <NA>    <NA>    <NA>
#>   st_dir bldg_type bldg_name level_type level_name unit_type unit_name sub_addr
#> 1   <NA>      <NA>      <NA>       <NA>       <NA>      <NA>      <NA>     <NA>
#>   st_addr block sector nbrhd district city metro_area subregion region
#> 1    <NA>  <NA>   <NA>  <NA>     <NA> <NA>       <NA>      <NA>   <NA>
#>   region_abbr territory zone postal postal_ext country cntry_name lang_code
#> 1        <NA>      <NA> <NA>   <NA>       <NA>    <NA>       <NA>      <NA>
#>   distance x y display_x display_y xmin xmax ymin ymax ex_info    geometry
#> 1        0 0 0         0         0    0    0    0    0    <NA> POINT EMPTY
```

<sup>Created on 2024-09-19 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>

Other than these minor issues the package works great! Really appreciate your work on this.