### PR TITLE
Replace deprecated pool arg w/ max_active in geocode_addresses()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,7 +20,7 @@ Imports:
     arcgisutils (>= 0.3.0),
     cli,
     curl,
-    httr2 (>= 1.0.5),
+    httr2 (>= 1.1.1),
     jsonify,
     RcppSimdJson,
     rlang (>= 1.1.0),

--- a/R/core-batch-geocode.R
+++ b/R/core-batch-geocode.R
@@ -277,7 +277,7 @@ geocode_addresses <- function(
     on_error = "continue",
     progress = .progress,
     # per Geocoding team request, reduce connection threads
-    pool = curl::new_pool(host_con = 3)
+    max_active = 3
   )
 
   # Before we can process the responses, we must know if


### PR DESCRIPTION
The latest version of httr2 started kicking back a warning due to the deprecation of the `pool` argument used by `geocode_addresses()` in version 1.1.1: https://httr2.r-lib.org/news/index.html#minor-improvements-and-bug-fixes-1-1-1

Not sure if you want to keep the version requirement lower but, if using the latest version of httr2 is fine, this resolves the issue.